### PR TITLE
Auto hide dropdown menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Gemfile.lock
 .DS_Store
 .idea/
 assets/.DS_Store
+/_site

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 
 Gemfile.lock
+.DS_Store
+.idea/
+assets/.DS_Store

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,22 +10,23 @@
         </button>
         <div class="collapse navbar-collapse" id="mainNav">
             <ul class="navbar-nav">
-                <li class="nav-item"><a href="{{ '/activities/' | absolute_url }}" class="nav-link">Activities</a></li>
-                <li class="nav-item"><a href="{{ '/about/' | absolute_url }}" class="nav-link">About</a></li>
-                <li class="nav-item"><a href="{{ '/team/' | absolute_url }}" class="nav-link">Team</a></li>
-                <li class="nav-item"><a href="https://chinacomx.github.io/translations/" class="nav-link" target="_blank">Translations</a></li>                <li class="nav-item"><a href="{{ '/publications/' | absolute_url }}" class="nav-link">Publications</a></li>
-                <li class="nav-item"><a href="{{ '/resources/' | absolute_url }}" class="nav-link">Resources</a></li>
-                <li class="nav-item"><a href="{{ '/contact/' | absolute_url }}" class="nav-link">Contact</a></li>
+                <li class="nav-item"><a href="{{ '/activities/' | relative_url }}" class="nav-link">Activities</a></li>
+                <li class="nav-item"><a href="{{ '/about/' | relative_url }}" class="nav-link">About</a></li>
+                <li class="nav-item"><a href="{{ '/team/' | relative_url }}" class="nav-link">Team</a></li>
+                <li class="nav-item"><a href="https://chinacomx.github.io/translations/" class="nav-link" target="_blank">Translations</a></li>                <li class="nav-item"><a href="{{ '/publications/' | relative_url }}" class="nav-link">Publications</a></li>
+                <li class="nav-item"><a href="{{ '/resources/' | relative_url }}" class="nav-link">Resources</a></li>
+                <li class="nav-item"><a href="{{ '/contact/' | relative_url }}" class="nav-link">Contact</a></li>
             </ul>
+            
             <div class="d-flex logos-right">
                 <a class="logo-link" href="https://erc.europa.eu/" title="to the Website of the European Research Center" target="_blank">
-                    <img src="{{ '/assets/images/erc-logo.png' | absolute_url }}" class="nav-logo">
+                    <img src="{{ '/assets/images/erc-logo.png' | relative_url }}" class="nav-logo">
                 </a>
                 <a class="logo-link" href="https://www.cats.uni-heidelberg.de/" title="to the Website of the CATS" target="_blank">
-                    <img src="{{ '/assets/images/cats-logo.png' | absolute_url }}" class="nav-logo">
+                    <img src="{{ '/assets/images/cats-logo.png' | relative_url }}" class="nav-logo">
                 </a>
                 <a class="logo-link" href="https://www.uni-heidelberg.de/" title="to the Website of the Heidelberg University" target="_blank">
-                    <img src="{{ '/assets/images/hd-logo.png' | absolute_url }}" class="nav-logo">
+                    <img src="{{ '/assets/images/hd-logo.png' | relative_url }}" class="nav-logo">
                 </a>
             </div>
         </div>
@@ -73,6 +74,16 @@
     .logos-right {
         margin-left: auto; /* Push the logos to the far right */
     }
+
+
+    .navbar-collapse {
+        display: none;
+    }
+
+    .navbar-collapse.show {
+        display: flex;
+    }
+
 </style>
 
 <script>
@@ -83,5 +94,13 @@
         toggler.addEventListener("click", function() {
             nav.classList.toggle("show");
         });
+
+        // Auto-hide menu when a link is clicked
+        nav.addEventListener("click", function(event) {
+            if (event.target.classList.contains("nav-link")) {
+                nav.classList.remove("show");
+            }
+        });
+
     });
 </script>

--- a/_site/jekyll/update/2024/10/10/FinissageHD.html
+++ b/_site/jekyll/update/2024/10/10/FinissageHD.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>
+            
+                Activities
+            
+        </title>
+        <link rel="stylesheet" href="/assets/css/style.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+        <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon">
+        <link rel="shortcut icon" href="/assets/images/favicon.ico" type="image/x-icon">                
+    <!-- Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-YPMHWP0DM3"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'YOUR_TRACKING_ID');
+</script>
+<!-- End Google Analytics -->
+
+
+    </head>    
+<body>
+    <header id="header" class="navbar navbar-expand-lg fixed-top navbar-light">
+    <div id="navigation-container" class="container-fluid">
+        <div class="logos-left">
+            <a href="/" title="ChinaComx Logo" class="navbar-brand">
+                <img src="/assets/images/chinacomx-logo.png" class="brand-logo">
+            </a>
+        </div>
+        <button class="navbar-toggler" type="button" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+            &#9776; <!-- Unicode for hamburger icon -->
+        </button>
+        <div class="collapse navbar-collapse" id="mainNav">
+            <ul class="navbar-nav">
+                <li class="nav-item"><a href="/activities/" class="nav-link">Activities</a></li>
+                <li class="nav-item"><a href="/about/" class="nav-link">About</a></li>
+                <li class="nav-item"><a href="/team/" class="nav-link">Team</a></li>
+                <li class="nav-item"><a href="https://chinacomx.github.io/translations/" class="nav-link" target="_blank">Translations</a></li>                <li class="nav-item"><a href="/publications/" class="nav-link">Publications</a></li>
+                <li class="nav-item"><a href="/resources/" class="nav-link">Resources</a></li>
+                <li class="nav-item"><a href="/contact/" class="nav-link">Contact</a></li>
+            </ul>
+            
+            <div class="d-flex logos-right">
+                <a class="logo-link" href="https://erc.europa.eu/" title="to the Website of the European Research Center" target="_blank">
+                    <img src="/assets/images/erc-logo.png" class="nav-logo">
+                </a>
+                <a class="logo-link" href="https://www.cats.uni-heidelberg.de/" title="to the Website of the CATS" target="_blank">
+                    <img src="/assets/images/cats-logo.png" class="nav-logo">
+                </a>
+                <a class="logo-link" href="https://www.uni-heidelberg.de/" title="to the Website of the Heidelberg University" target="_blank">
+                    <img src="/assets/images/hd-logo.png" class="nav-logo">
+                </a>
+            </div>
+        </div>
+    </div>
+</header>
+
+
+<style>
+    .navbar {
+        width: 100%;
+    }
+
+    .navbar-brand img {
+        max-height: 200px; /* Adjust the height of the logo as needed */
+    }
+
+    .nav-logo {
+        max-height: 200px; /* Adjust the height of the logos on the right as needed */
+        width: auto;
+        margin-left: 10px; /* Space between logos */
+    }
+
+    .navbar-nav {
+        margin: 0 auto; /* Center the navigation links */
+        display: flex;
+        justify-content: center;
+        flex: 1;
+    }
+
+    .nav-link {
+        padding: 0.5px 0.5px; /* Adjust spacing around navigation links */
+    }
+
+    .navbar-collapse {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    .logos-left, .logos-right {
+        display: flex;
+        align-items: center;
+    }
+
+    .logos-right {
+        margin-left: auto; /* Push the logos to the far right */
+    }
+
+
+    .navbar-collapse {
+        display: none;
+    }
+
+    .navbar-collapse.show {
+        display: flex;
+    }
+
+</style>
+
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        const toggler = document.querySelector(".navbar-toggler");
+        const nav = document.querySelector("#mainNav");
+
+        toggler.addEventListener("click", function() {
+            nav.classList.toggle("show");
+        });
+
+        // Auto-hide menu when a link is clicked
+        nav.addEventListener("click", function(event) {
+            if (event.target.classList.contains("nav-link")) {
+                nav.classList.remove("show");
+            }
+        });
+
+    });
+</script>
+
+    <main class="content-wrapper">
+        <div class="page-header">
+            
+                <h1>Activities</h1>
+            
+        </div>
+        <div class="page-content">
+            <article class="post-page">
+    <h1 class="post-title">Closing Event of a Lianhuanha Exhibition at the CATS Library with ChinaComx</h1>
+    <p class="post-date">10 October 2024</p>
+    <div class="post-content">
+        
+        <img class="hero-image" src="/assets/images/FinissageHD.png" alt="Closing Event of a Lianhuanha Exhibition at the CATS Library with ChinaComx">
+    
+        <p>On 15 October 2024 the <a href="https://www.cats.uni-heidelberg.de/library/">CATS Library</a> would like to cordially invite you to the finissage of our exhibition <a href="https://www.cats.uni-heidelberg.de/bibliothek/ausstellungen/comics.html">“Comics from China: Entertainment – Realities – Propaganda?”</a>!</p>
+
+<p>The finissage offers a last opportunity to view the exhibition, after which Lena Henningsen and Damian Mandzunowski from the ERC project “ChinaComx”, newly established at CATS, will give a keynote speech on the roles of heroes and villains in comics of the Mao era.</p>
+
+<p>In addition, three wonderful animated short films by young Chinese artists will round off the programme. Of course, a small buffet will also be provided for your physical well-being!</p>
+
+<p>Program:</p>
+<ul>
+  <li>18:30     Welcome and exhibition tour, Foyer, CATS Library</li>
+  <li>19:00     Keynote: “Into the Maoverse: Heroes and Villains in Chinese Comics,” Lena Henningsen &amp; Damian Mandzunowski (ERC-ChinaComx), CATS Auditorium (R.010.01.05)</li>
+  <li>19:45     Film screening: Animated shorts from the Nanjing University of the Arts 南京艺术学院:
+    <ul>
+      <li>当我再次走进厨房 (Now I’m in the Kitchen), dir.: Yana Pan 潘亭钰, 2022</li>
+      <li>每天朝山顶推一秒的石头 (Being Sisyphus for One Second a Day), dir.: Peixuan Cheng 成佩轩, 2021</li>
+      <li>雾上清晨 (Beyond the Fog), dir.: Xue Feng 薛峰, 2021</li>
+    </ul>
+  </li>
+  <li>End of the event around 20:30.</li>
+</ul>
+
+<p><em>Creating the exhibition was part of a seminar of the Institute of East Asian Art History; for the names of the participating students please refer to the <a href="https://www.cats.uni-heidelberg.de/bibliothek/ausstellungen/comics.html">exhibition’s webpage</a>.</em></p>
+
+    </div>
+    <footer class="post-footer">
+        <nav class="post-navigation">
+            
+                <a href="/jekyll/update/2024/09/27/LenaEdinburgh.html" class="prev-post">Previous Activity</a>
+            
+            
+        </nav>
+    </footer>
+</article>
+
+        </div>
+    </main>
+    <footer>
+    <div class="container">
+        <div class="footer-social">
+            <a href="https://x.com/zhong_daming" target="_blank"><i class="fab fa-twitter"></i></a>
+            <a href="https://bsky.app/profile/damiandamiani.bsky.social" target="_blank"><i class="fab fa-rebel"></i></a>
+            <a href="https://github.com/chinacomx" target="_blank"><i class="fab fa-github"></i></a>
+        </div>
+        <p>&copy; 2024-2028 ChinaComx, ERC, & Heidelberg University</p>
+    </div>
+</footer>
+
+    <script>
+        document.addEventListener("DOMContentLoaded", function() {
+            const header = document.getElementById("header");
+            header.classList.add("show");
+        });
+    </script>
+</body>
+</html>
+

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -970,7 +970,7 @@ body.home .footer-social {
 body.home .footer-social a img {
     width: 24px;
     margin: 0 10px
-
+}
     
 /* Carousel */  
     .carousel {
@@ -983,7 +983,7 @@ body.home .footer-social a img {
         gap: 16px;
         justify-content: center;
     }
-} 
+
       .carousel-inner {
         overflow: hidden;
       }

--- a/team.md
+++ b/team.md
@@ -14,7 +14,7 @@ The **ChinaComx** team are the following people:
 - Astrid XIAO, PhD Candidate,  is analyzing the aesthetics and theories of comics, particularly focusing on children’s lianhuanhua, educational policies, and adaptations.
 - Aijia ZHANG, PhD Candidate, is identifying recurrent imageries in lianhuanhua with computational methods to understand how they contributed to the identity building of their readers.
   
-Jérémy BIEHLER, Qin GU, and Bettina JIN are our current Research Assistants. 
+Jérémy BIEHLER, Qin GU, Bettina JIN, and XU Haoran are our current Research Assistants. 
 
 <!-- 
 

--- a/team.md
+++ b/team.md
@@ -6,7 +6,7 @@ permalink: /team/
 
 The **ChinaComx** team are the following people:
 
-![ChinaComx in from of CATS in October 2024](assets/images/TeamPhotoOct2024.JPG)
+![ChinaComx in from of CATS in October 2024](/assets/images/TeamPhotoOct2024.JPG)
 
 - [Lena HENNINGSEN](https://www.zo.uni-heidelberg.de/sinologie/institute/staff/henningsen/), Principal Investigator, is writing about adaptations of literary texts into lianhuanhua with a specific focus on the literature of Lu Xun. ➡️ 👨🏻‍💻 [ResearchGate](https://www.researchgate.net/profile/Lena-Henningsen) 🟢 [ORCiD](https://orcid.org/0000-0001-7583-0920)
 - [Damian MANDZUNOWSKI](https://www.zo.uni-heidelberg.de/sinologie/institute/staff/mandzunowski/), PostDoc Researcher, is working on the contemporary history of lianhuanhua through the lenses of politics, culture, and daily life. ➡️ 👨🏻‍💻 [ResearchGate](https://www.researchgate.net/profile/Damian-Mandzunowski) 🟢 [ORCiD](https://orcid.org/my-orcid?orcid=0000-0002-3318-6652) 𝕏 [Twitter](https://x.com/zhong_daming) ⚫️ [GitHub](https://github.com/damianodamiani)


### PR DESCRIPTION
There are a few changes:
1. added JS script for auto-hiding the dropdown menu
2. added CSS code accordingly
3. update the url setting in `_includes/header.html` to avoid using local host url, for example, `href="/contact/"` instead of `href="http://localhost:4000/contact/"`
4. update gitignore for preventing committing `_site`
5. a small fix for team photo url in `team.md`

Checked in the following ways:

- [x]  run `bundle exec jekyll serve` on terminal and examine the given server address to see if the dropdown menu could hide automatically.
- [x] run `bundle exec jekyll serve --host 0.0.0.0` to bind the server to local machine’s IP address and make the website accessible on local network, then use something like http://192.168.1.10:4000/ (replace 192.168.1.10 with the correct computer's IP address) on mobile device to double check if the dropdown menu could hide automatically.
- [x]  run private/incognito browsing mode on both PC and mobile device to check the dropdown menu's hiding feature.
- [ ] check the spread menu in PC browser when it is not in the collapsed status.

see #31 #15